### PR TITLE
add script for generating new report

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# CONTRIBUTING
+
+When contributing to this repository, please first discuss the change you wish to make via issue, email,
+or any other method with the owners of this repository before making a change.
+
+To start contribute to this project, you can clone this repository, install required dependencies
+(using `yarn` is extremely preferred), then in your terminal you can execute this command:
+
+```bash
+yarn new "Title" "version" "Description" "Author"
+```
+
+For example:
+
+```bash
+yarn new "Svelte" 3 "Cybernetically enhanced web apps" "faultable"
+```
+
+Above script will generate you a new "report" based on our template! You can start editing the
+report by opening your code editor to "slug-style" of title and version format under `pages/reports/`
+directory.
+
+```bash
+vim pages/reports/svelte-3.mdx
+```
+
+That's it!

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "start": "next start",
     "dev": "next dev",
-    "generate": "next build && next export"
+    "generate": "next build && next export",
+    "new": "node scripts/new.js"
   },
   "dependencies": {
     "@mapbox/rehype-prism": "^0.3.1",

--- a/scripts/new.js
+++ b/scripts/new.js
@@ -1,0 +1,144 @@
+// This script to help you "start new" report
+
+const { mkdirSync, writeFileSync, existsSync } = require('fs')
+const { resolve, sep } = require('path')
+
+const [_, __, title, version, description, author] = process.argv
+
+if (process.argv.length < 5) {
+  console.log()
+  console.log('Error: Wrong format')
+  console.log(
+    'Usage: yarn new "<title>" "<version>" "<description>" "<github username">'
+  )
+  console.log()
+  console.log(
+    'e.g: yarn new "React" 19 "React is JavaScript Library" "faultable"'
+  )
+  console.log()
+  process.exit(1)
+}
+
+const targetPath = resolve(__dirname, '..', 'pages', 'reports')
+
+const slugify = text => {
+  return text
+    .toString()
+    .toLowerCase()
+    .replace(/\s+/g, '-')
+    .replace(/[^\w\-]+/g, '')
+    .replace(/\-\-+/g, '-')
+    .replace(/^-+/, '')
+    .replace(/-+$/, '')
+}
+
+const months = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec'
+]
+
+const createFile = _ => {
+  if (existsSync(resolve(targetPath, fileFormat))) {
+    console.log()
+    console.log('> file exists. Consider to edit it?')
+    console.log()
+    process.exit(1)
+  }
+
+  try {
+    writeFileSync(resolve(targetPath, fileFormat), template)
+  } catch (err) {
+    throw Error(err)
+  }
+}
+
+const shouldAddZero = number => number <= 9 && '0'
+
+const date = new Date()
+const currentDate = date.getDate()
+const $date = shouldAddZero(currentDate) + currentDate
+const $month = months[date.getMonth() + 1]
+const $year = date.getFullYear()
+
+const dateFormat = `${$month} ${$date}, ${$year}`
+const footerDateFormat = `${$date} ${$month} ${$year}`
+const fileFormat = `${slugify(title)}-${version}.mdx`
+const template = `import Meta from '../../components/Meta'
+
+export const meta = {
+  title: '${title} v${version} report by evilfactorylabs RNDC',
+  isPublished: false,
+  published: '${dateFormat}',
+  description: '${description}'
+}
+
+export default ({ children }) => <Meta meta={meta}>{children}</Meta>
+
+# ${title}
+
+${description}
+
+### Latar Belakang
+
+#### Sejarah Singkat
+
+...
+
+#### Masalah yang dipecahkan
+
+- 
+
+### Key Concepts
+
+- 
+
+### Core Features
+
+- 
+
+### Under The Hood (Key Concepts)
+
+...
+
+### Core Features
+
+...
+
+### Stats
+
+#### Kompleksitas
+
+...
+
+#### Adopsi
+
+...
+
+#### Alternatif
+
+...
+
+### Referensi
+
+- 
+
+---
+
+Diterbitkan pada ${footerDateFormat} oleh [${author}](https://github.com/${author}).
+`
+
+createFile()
+
+console.log()
+console.log('> Created here: ' + resolve(targetPath, fileFormat))
+console.log()


### PR DESCRIPTION
In this PR I create a script to make "create new report" easier. All you need is only to execute this command:

```bash
yarn new "Title" version "Description" "Author"
```

For example:

```bash
yarn new "React" 19 "React is JavaScript library for building User Interface" "faultable"
```

Author is referred to your GitHub username, and we use version here for the context because a report of React v16 and React v17 will be different since they have bumped the major version. 